### PR TITLE
recursive directory creation

### DIFF
--- a/neuVid/utilsMeshes.py
+++ b/neuVid/utilsMeshes.py
@@ -17,7 +17,7 @@ def ensure_directory(parent, dir):
     path = os.path.join(parent, dir)
     try:
         if not os.path.exists(path):
-            os.mkdir(path)
+            os.makedirs(path)
     except OSError as e:
         print("Error: cannot create directory {}".format(path))
         sys.exit()
@@ -99,7 +99,7 @@ def fileToImportForRoi(source, roiName, parentForDownloadDir, skipExisting):
         if mesh:
             try:
                 if not os.path.exists(downloadDir):
-                    os.mkdir(downloadDir)
+                    os.makedirs(downloadDir)
                 if roiName.endswith(".ngmesh"):
                     with BytesIO(mesh) as meshBinStream:
                         verticesXYZ, faces = read_ngmesh(meshBinStream)


### PR DESCRIPTION
`os.makedirs()` is a drop-in replacement for `os.mkdir()` and creates a directory structures recursively.

This is more likely to happen with the `--cachdir` option from cb46fd043dc6c973af67310de358ef8aeb590168

The code could be further shortened by replacing 

```python
if not os.path.exists(path):
    os.makedirs(path)
```

with

```python
os.makedirs(path, exists_ok=True)
```