### PR TITLE
fix issue #157

### DIFF
--- a/neuVid/addAnimation.py
+++ b/neuVid/addAnimation.py
@@ -488,6 +488,8 @@ def fadeCmd(args):
     if "meshes" in args:
         meshes = args["meshes"]
         objs = meshObjs(meshes)
+        if objs is None: # empty list of meshes skips the fade
+            return
 
         startingTime = time
         deltaTime = []


### PR DESCRIPTION
`meshObjs()` returns `None` when the list of object names is 0 (line 132) as opposed to an empthy list when the objects can't be fetched. If issues #157 is not a 'wontfix', then the check for None here would cover the case of supplying an empty list.