### PR TITLE
switch to H264 for >=blender-4.2

### DIFF
--- a/neuVid/assembleFrames.py
+++ b/neuVid/assembleFrames.py
@@ -111,7 +111,13 @@ bpy.context.scene.render.resolution_percentage = 100
 bpy.context.scene.render.pixel_aspect_x = 1
 bpy.context.scene.render.pixel_aspect_y = 1
 
-bpy.context.scene.render.image_settings.file_format = "AVI_JPEG"
+if bpy.app.version < (4, 2, 0):
+    bpy.context.scene.render.image_settings.file_format = "AVI_JPEG"
+else :
+    bpy.context.scene.render.image_settings.file_format = "FFMPEG"
+    bpy.context.scene.render.ffmpeg.format = "AVI"
+    bpy.context.scene.render.ffmpeg.codec = "H264"
+
 bpy.context.scene.render.fps = 24
 
 bpy.context.scene.render.filepath = outputDir


### PR DESCRIPTION
Blender 4.2 doesn't seem to support the output file format  "AVI_JPEG" anymore and I suggest to switch to H264 (also see #193). Keeping the AVI container for backward compatibility.